### PR TITLE
if OS has booted from overlay partition on mmcblk0 device, exit the script

### DIFF
--- a/omega2pro/Makefile
+++ b/omega2pro/Makefile
@@ -27,7 +27,7 @@ define Package/omega2-pro-base
 	CATEGORY:=Onion
 	SUBMENU:=Utilities
 	TITLE:=Omega2 Pro base packages and configuration
-	DEPENDS:=+fdisk +e2fsprogs +block-mount +swap-utils
+	DEPENDS:=+fdisk +e2fsprogs +block-mount +swap-utils +tar @TARGET_DEVICE_ramips_mt76x8_DEVICE_omega2pro
 endef
 
 define Package/omega2-pro/description

--- a/omega2pro/files/o2-pro-init.sh
+++ b/omega2pro/files/o2-pro-init.sh
@@ -2,23 +2,28 @@
 
 storageDev=mmcblk0p1
 swapSize=384 # 512 - 128 MB
+blockInfo=$(mktemp)
 
-# TODO: if OS has booted from overlay partition on mmcblk0 device, exit the script!
+block info > $blockInfo
 
-# TODO: if an ext4 partition 1 already exists, skip this step
-#Format SD card
-(
-echo d # Delete all partitions
-echo n # Add a new partition
-echo p # Primary partition
-echo   # Partition number (Accept default)
-echo   # First sector (Accept default: 1)
-echo   # Last sector (Accept default: varies)
-# echo y # confirm removal of partition signature
-echo w # Write changes
-) | fdisk /dev/mmcblk0
+# if OS has booted from overlay partition on mmcblk0 device, exit the script!
+awk -F'[ :=]' 'BEGIN {err = 1;} {if (($1 ~ "'$storageDev'") && ($8 ~ "/overlay")) {err = 0;}} END {exit err;}' $blockInfo && exit 0
 
-echo y | mkfs.ext4 /dev/$storageDev
+# format SD card, if an ext4 partition 1 does not exists
+awk -F'[ :=]' 'BEGIN {err = 1;} {if (($1 ~ "'$storageDev'") && ($10 ~ "ext4")) {err = 0;}} END {exit err;}' $blockInfo || {
+	#Format SD card
+	(
+	echo d # Delete all partitions
+	echo n # Add a new partition
+	echo p # Primary partition
+	echo   # Partition number (Accept default)
+	echo   # First sector (Accept default: 1)
+	echo   # Last sector (Accept default: varies)
+	# echo y # confirm removal of partition signature
+	echo w # Write changes
+	) | fdisk /dev/mmcblk0
+	echo y | mkfs.ext4 /dev/$storageDev
+}
 
 # we need to create the startup scrpt before duplcating overlay
 cat > /etc/init.d/swapon <<EOF
@@ -37,11 +42,11 @@ EOF
 chmod +x /etc/init.d/swapon
 /etc/init.d/swapon enable
 
-# TODO: if there is already an overlay filesystem on the emmc:
+# if there is already an overlay filesystem on the emmc:
 #	* do not overwrite the /root directory 
 # 	* do not overwrite changes to /etc/config/ files
 #duplicate /overlay
-mount /dev/$storageDev /mnt/ ; tar -C /overlay -cvf - . | tar -C /mnt/ -xf - ; umount /mnt/
+mount /dev/$storageDev /mnt/ ; tar -C /overlay -cvf - . | tar --exclude='./upper/root' --exclude='./upper/etc/config' -C /mnt/ -xf - ; umount /mnt/
 
 # auto mount /overlay
 block detect > /etc/config/fstab
@@ -50,12 +55,12 @@ uci set fstab.@mount[0].target='/overlay'
 uci commit
 /etc/init.d/fstab enable
 
-
 # create swap file
 mount /dev/$storageDev /mnt/
 dd if=/dev/zero of=/mnt/swap.page bs=1M count=$swapSize
 mkswap /mnt/swap.page
 
+rm -f $blockInfo
 
 echo "> Done. Rebooting in 3 seconds..."
 sleep 3


### PR DESCRIPTION
if OS has booted from overlay partition on mmcblk0 device, exit the script

format SD card, if an ext4 partition 1 does not exists
if there is already an overlay filesystem on the emmc
    * do not overwrite the /root directory
    * do not overwrite changes to /etc/config/ files
Set target dependencies for omega2pro