### PR TITLE
merge lted-run with lted

### DIFF
--- a/omega2-lte/files/init.d/lted.sh
+++ b/omega2-lte/files/init.d/lted.sh
@@ -4,13 +4,18 @@ START=90
 
 USE_PROCD=1
 
-BIN="lted-run"
+BIN="lted"
 APN=$(uci -q get onion.@onion[0].apn)
+IFN=$(uci -q get network.lte.ifname)
 
 start_service() {
-    [ "$APN" != "" ] && {
+    [ "$APN" != "" ] && [ "$IFN" != "" ] && {
+        # do lted-run stuff locally
+        ifconfig $IFN down
+        echo "Y" > /sys/class/net/$IFN/qmi/raw_ip
+
         procd_open_instance
-        procd_set_param command $BIN $APN
+        procd_set_param command $BIN -s $APN
         procd_set_param respawn  # respawn the service if it exits
         procd_set_param stdout 1 # forward stdout of the command to logd
         procd_set_param stderr 1 # same for stderr


### PR DESCRIPTION
This is done because procd only controls the command it is given. Which means when stopping this service lted-run was stopped but not its children (lted).

Fixes #37.