### PR TITLE
[Issue-65]: fix omega2-usb-autorun autorun

### DIFF
--- a/omega2-base/Makefile
+++ b/omega2-base/Makefile
@@ -50,7 +50,7 @@ define Package/omega2-usb-autorun
 	CATEGORY:=Onion
 	SUBMENU:=Base system
 	TITLE:=Omega2 family USB autorun package
-	#DEPENDS:=
+	DEPENDS:=rpcd
 endef
 
 define Package/omega2-usb-autorun/description


### PR DESCRIPTION
- add missing dependency of rpcd