### PR TITLE
[Issue-77]: change gpio mappings for spi

### DIFF
--- a/onion-dt-overlay/Makefile
+++ b/onion-dt-overlay/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=onion-dt-overlay
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 KERNEL_BUILD_DIR ?= $(BUILD_DIR)/linux-$(BOARD)$(if $(SUBTARGET),_$(SUBTARGET))
 LINUX_DIR ?= $(KERNEL_BUILD_DIR)/linux-$(LINUX_VERSION)
 DTC=$(LINUX_DIR)/scripts/dtc/dtc

--- a/onion-dt-overlay/src/sw-spi.dts
+++ b/onion-dt-overlay/src/sw-spi.dts
@@ -8,10 +8,10 @@
         compatible = "spi-gpio";
         #address-cells = <0x1>;
         #size-cells = <0x0>;
-        sck-gpios = <&gpio 11 0>;
-        mosi-gpios = <&gpio 5 0>;
-        miso-gpios = <&gpio 4 0>;
-        cs-gpios = <&gpio 23 0>;
+        sck-gpios = <&gpio 14 0>;
+        mosi-gpios = <&gpio 16 0>;
+        miso-gpios = <&gpio 15 0>;
+        cs-gpios = <&gpio 17 0>;
         num-chipselects = <1>;
 
         spi-max-frequency = <100000>;


### PR DESCRIPTION
reasons to change spi gpio mapping

-----------------------------------------------------------
|SPI Signal |            Old GPIO              | New GPIO |
-----------------------------------------------------------
|SCK        | 11 (bootloader programs it high) | 14       |
|MOSI       |  5 (I2C bus SDA signal)          | 16       |
|MISO       |  4 (I2C bus SDA signal)          | 15       |
|CS         | 23 (Not pinned out on Omega2/2+) | 17       |
-----------------------------------------------------------