### PR TITLE
[Issue-76]: change w1-gpio to GPIO2

### DIFF
--- a/onion-dt-overlay/Makefile
+++ b/onion-dt-overlay/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=onion-dt-overlay
 PKG_VERSION:=1.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 KERNEL_BUILD_DIR ?= $(BUILD_DIR)/linux-$(BOARD)$(if $(SUBTARGET),_$(SUBTARGET))
 LINUX_DIR ?= $(KERNEL_BUILD_DIR)/linux-$(LINUX_VERSION)
 DTC=$(LINUX_DIR)/scripts/dtc/dtc

--- a/onion-dt-overlay/src/w1-gpio.dts
+++ b/onion-dt-overlay/src/w1-gpio.dts
@@ -8,7 +8,7 @@
 		__overlay__ {
 			onewire:onewire {
 				compatible = "w1-gpio";
-				gpios = <&gpio 19 0>;
+				gpios = <&gpio 2 0>;
 				status = "okay";
 			};
 		};


### PR DESCRIPTION
- use of GPIO19 is not ideal as it takes up hw PWM channel1