### PR TITLE
Fix onion-dt-overlay postinst script to have error-free build

### DIFF
--- a/onion-dt-overlay/Makefile
+++ b/onion-dt-overlay/Makefile
@@ -68,7 +68,12 @@ define BuildDtbo
   define Package/onion-dt-overlay-$(1)/postinst
 	#!/bin/sh
 
-	if [ -z "$${IPKG_INSTROOT}" ]; then
+	if [ -z "$$$${IPKG_INSTROOT}" ]; then
+		if ! cat /proc/mounts | grep -q config; then
+			echo "Mounting configfs..."
+			mount -t configfs none /sys/kernel/config
+		fi
+
 		mkdir -p /sys/kernel/config/device-tree/overlays/$(1)
 		cat /lib/firmware/device-tree/overlays/$(1).dtbo > /sys/kernel/config/device-tree/overlays/$(1)/dtbo
 	fi


### PR DESCRIPTION
Build fails if onion-dt-overlay-sw-spi package is included (*) in build and works fine if only package building is (M) enabled. Onion-dt-overlay package postinst script tries to create /sys/kernel/config/ directory which is not allowed during image building process.
The fix introduces correct usage of IPKG_INSTROOT variable in bash, so the postinst script should be executed only on a target hardware.

Resolves: #91